### PR TITLE
add Bitwarden.eu

### DIFF
--- a/app-profiles/service/bitwarden/README.md
+++ b/app-profiles/service/bitwarden/README.md
@@ -23,4 +23,11 @@ The table below contains all the endpoints that are used by the application.
 | sso.bitwarden.com           | ✔️         |
 | icons.bitwarden.net         | ✔️         |
 | notifications.bitwarden.com | ❌         |
-
+| api.bitwarden.eu            | ❌         |
+| events.bitwarden.eu         | ❌         |
+| func.bitwarden.eu           | ❌         |
+| identity.bitwarden.eu       | ❌         |
+| scim.bitwarden.eu           | ❌         |
+| sso.bitwarden.eu            | ❌         |
+| icons.bitwarden.eu          | ❌         |
+| notifications.bitwarden.eu  | ❌         |

--- a/app-profiles/service/bitwarden/bitwarden.yml
+++ b/app-profiles/service/bitwarden/bitwarden.yml
@@ -21,6 +21,14 @@ config:
             - + sso.bitwarden.com TCP/HTTPS
             - + icons.bitwarden.net TCP/HTTPS
             - + notifications.bitwarden.com TCP/HTTPS
+            - + api.bitwarden.eu TCP/HTTPS
+            - + events.bitwarden.eu TCP/HTTPS
+            - + func.bitwarden.eu TCP/HTTPS
+            - + identity.bitwarden.eu TCP/HTTPS
+            - + scim.bitwarden.eu TCP/HTTPS
+            - + sso.bitwarden.eu TCP/HTTPS
+            - + icons.bitwarden.eu TCP/HTTPS
+            - + notifications.bitwarden.eu TCP/HTTPS
 lastEdited: 2024-04-02T05:29:31-05:00
 created: 2024-03-29T15:30:59-05:00
 


### PR DESCRIPTION
Bitwarden has the option for an official EU server hosted on the domain bitwarden.eu
you can find it in the drop down at the bottom here https://vault.bitwarden.com/#/login
This doc also mentions it https://bitwarden.com/help/server-geographies/